### PR TITLE
#21: Disable the tracking of skulls with config option

### DIFF
--- a/src/main/java/ca/tweetzy/skulls/Skulls.java
+++ b/src/main/java/ca/tweetzy/skulls/Skulls.java
@@ -97,7 +97,9 @@ public final class Skulls extends FlightPlugin {
 		// events
 		getServer().getPluginManager().registerEvents(new PlayerJoinQuitListener(), this);
 		getServer().getPluginManager().registerEvents(new PlayerDeathListener(), this);
-		getServer().getPluginManager().registerEvents(new SkullBlockListener(), this);
+		if (Settings.SKULL_TRACKING.getBoolean()) {
+			getServer().getPluginManager().registerEvents(new SkullBlockListener(), this);
+		}
 	}
 
 	public static Skulls getInstance() {

--- a/src/main/java/ca/tweetzy/skulls/manager/SkullManager.java
+++ b/src/main/java/ca/tweetzy/skulls/manager/SkullManager.java
@@ -28,6 +28,7 @@ import ca.tweetzy.skulls.api.interfaces.PlacedSkull;
 import ca.tweetzy.skulls.api.interfaces.Skull;
 import ca.tweetzy.skulls.impl.InsertHistory;
 import ca.tweetzy.skulls.impl.TexturedSkull;
+import ca.tweetzy.skulls.settings.Settings;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -299,14 +300,16 @@ public final class SkullManager implements Manager {
 			}
 		});
 
-		Skulls.getDataManager().getPlacedSkulls((error, all) -> {
-			if (error != null) {
-				error.printStackTrace();
-				return;
-			}
+		if (Settings.SKULL_TRACKING.getBoolean()) {
+			Skulls.getDataManager().getPlacedSkulls((error, all) -> {
+				if (error != null) {
+					error.printStackTrace();
+					return;
+				}
 
-			all.forEach(placedSkull -> this.placedSkulls.put(placedSkull.getLocation(), placedSkull));
-		});
+				all.forEach(placedSkull -> this.placedSkulls.put(placedSkull.getLocation(), placedSkull));
+			});
+		}
 
 		Skulls.getDataManager().getHistories((error, all) -> {
 			if (error != null) {

--- a/src/main/java/ca/tweetzy/skulls/settings/Settings.java
+++ b/src/main/java/ca/tweetzy/skulls/settings/Settings.java
@@ -40,6 +40,7 @@ public final class Settings extends FlightSettings {
 	public static final ConfigEntry MAIN_MENU_REQUIRES_NO_PERM = create("main menu requires no permission", true);
 	public static final ConfigEntry GENERAL_USAGE_REQUIRES_NO_PERM = create("general usage requires no permission", false, "If true, no permission is required to use except for admin stuff");
 	public static final ConfigEntry TELL_OP_PATREON_LINK = create("tell ops patron on join", true);
+	public static final ConfigEntry SKULL_TRACKING = create("track skull placement", true, "If disabled skulls will no longer drop in creative");
 
 	public static final ConfigEntry CATEGORIES_ALPHABET_ENABLED = create("enabled categories.alphabet", true);
 	public static final ConfigEntry CATEGORIES_ANIMALS_ENABLED = create("enabled categories.animals", true);


### PR DESCRIPTION
Implements #21 

Reasons:
- Prevents skulls from droping in creative mode.
- The server no longer needs to keep track of all placed skulls.