### PR TITLE
fix: towny head duplication glitch

### DIFF
--- a/src/main/java/ca/tweetzy/skulls/listeners/SkullBlockListener.java
+++ b/src/main/java/ca/tweetzy/skulls/listeners/SkullBlockListener.java
@@ -90,6 +90,7 @@ public final class SkullBlockListener implements Listener {
 				continue;
 
 			item.setItemStack(skull.getItemStack());
+			break;
 		}
 	}
 }


### PR DESCRIPTION
**NOTE!** I have yet to test this branch as I can't compile the plugin because of missing dependencies. 

### Reproduction Steps
This requires two players (A and B), and a Town.

1. **Player A** can build in a Town. **Player B** can not.
2. **Player A** Places a skull inside the Town.
3. **Player B** tries to destroy the head. 
4. This drops the Skull, but does not remove the block (*As Towny protects the town*).
5. **Player A** can place the newly dropped skull, and **Player B** can repeat the method on it to duplicate skulls.

### Patch
I switched from `BlockBreakEvent` to `BlockDropItemEvent` as the latter will only run if the `BlockBreakEvent` is successful. The result is greater compatibility with all land-protection plugins, as Skulls can completely leave them to do their job without having to invasively hook in to check for permissions.
