### PR TITLE
feat(api): player skull drop events

### DIFF
--- a/src/main/java/ca/tweetzy/skulls/api/events/PlayerPreSkullDropEvent.java
+++ b/src/main/java/ca/tweetzy/skulls/api/events/PlayerPreSkullDropEvent.java
@@ -1,0 +1,65 @@
+package ca.tweetzy.skulls.api.events;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Triggered before a skull has been dropped when a player died.
+ * Cancelling this event will prevent the Skull from dropping.
+ */
+public class PlayerPreSkullDropEvent extends Event implements Cancellable {
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+    private boolean cancelled;
+    private final Player player;
+    private final Location dropLocation;
+    private final ItemStack skull;
+
+    public PlayerPreSkullDropEvent(Player player, Location dropLocation, ItemStack skull) {
+        this.player = player;
+        this.dropLocation = dropLocation;
+        this.skull = skull;
+    }
+
+    /**
+     * Get the dead player
+     * @return player
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Get the location where the item will be dropped (A random offset is added when the item is dropped)
+     * @return location
+     */
+    public Location getDropLocation() {
+        return dropLocation;
+    }
+
+    /**
+     * Get the item-stack (skull) that will be dropped
+     * @return item-stack
+     */
+    public ItemStack getSkull() {
+        return skull;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+}

--- a/src/main/java/ca/tweetzy/skulls/api/events/PlayerSkullDropEvent.java
+++ b/src/main/java/ca/tweetzy/skulls/api/events/PlayerSkullDropEvent.java
@@ -1,0 +1,41 @@
+package ca.tweetzy.skulls.api.events;
+
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Triggered after a skull has been dropped when a player died.
+ */
+public class PlayerSkullDropEvent extends Event {
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+    private final Player player;
+    private final Item skull;
+
+    public PlayerSkullDropEvent(Player player, Item skull) {
+        this.player = player;
+        this.skull = skull;
+    }
+
+    /**
+     * Get the dead player
+     * @return player
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Get the item (skull) that was dropped
+     * @return item
+     */
+    public Item getSkull() {
+        return skull;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+}

--- a/src/main/java/ca/tweetzy/skulls/listeners/PlayerDeathListener.java
+++ b/src/main/java/ca/tweetzy/skulls/listeners/PlayerDeathListener.java
@@ -19,12 +19,18 @@
 package ca.tweetzy.skulls.listeners;
 
 import ca.tweetzy.flight.utils.QuickItem;
+import ca.tweetzy.skulls.api.events.PlayerPreSkullDropEvent;
+import ca.tweetzy.skulls.api.events.PlayerSkullDropEvent;
 import ca.tweetzy.skulls.settings.Settings;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.Random;
 
@@ -38,7 +44,21 @@ public final class PlayerDeathListener implements Listener {
 		final Random random = new Random();
 
 		if (random.nextDouble() * 100D < Settings.PLAYER_HEAD_DROP_CHANCE.getInt()) {
-			player.getWorld().dropItemNaturally(player.getLocation(), QuickItem.of(player).name(Settings.PLAYER_HEAD_NAME.getString().replace("%player_name%", player.getName())).make());
+			final Location dropLocation = player.getLocation();
+			final ItemStack skull = QuickItem.of(player).name(Settings.PLAYER_HEAD_NAME.getString().replace("%player_name%", player.getName())).make();
+
+			// Send pre-skull drop event
+			PlayerPreSkullDropEvent preEvent = new PlayerPreSkullDropEvent(player, dropLocation, skull);
+			Bukkit.getPluginManager().callEvent(preEvent);
+			if (preEvent.isCancelled())
+				return;
+
+			// Drop skull
+			Item droppedSkull = player.getWorld().dropItemNaturally(dropLocation, skull);
+
+			// Send skull drop event
+			PlayerSkullDropEvent postEvent = new PlayerSkullDropEvent(player, droppedSkull);
+			Bukkit.getPluginManager().callEvent(postEvent);
 		}
 	}
 }


### PR DESCRIPTION
Adds two events `PlayerPreSkullDropEvent` and `PlayerSkullDropEvent` which allows plugin developers to react to player heads being dropped on death. 

The first event is cancellable allowing developers to prevent heads dropping. (*Let's say in a PvP arena or such, where you might want to override the configured behavior.*)