### PR TITLE
Added verification of the block-place flag

### DIFF
--- a/src/main/java/ca/tweetzy/skulls/hooks/WorldGuardHook.java
+++ b/src/main/java/ca/tweetzy/skulls/hooks/WorldGuardHook.java
@@ -44,7 +44,8 @@ public final class WorldGuardHook {
 		if (WorldGuard.getInstance().getPlatform().getSessionManager().hasBypass(WorldGuardPlugin.inst().wrapPlayer(player), world))
 			return true;
 
-		return query.testState(loc, WorldGuardPlugin.inst().wrapPlayer(player), Flags.BUILD);
+		// BUILD and BLOCK-PLACE flags are verified
+		return query.testState(loc, WorldGuardPlugin.inst().wrapPlayer(player), Flags.BUILD, Flags.BLOCK_PLACE);
 	}
 
 	public boolean isAllowedBreak(@NonNull final Player player, @NonNull final Block block) {


### PR DESCRIPTION
This is necessary because otherwise, when the user wants to activate only the BLOCK-PLACE flag, he has to also enable BUILD, and then deny BLOCK-BREAK.
