### PR TITLE
refactor: Separate Vault economy into Legacy and VaultUnlocked implementations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <jarName>Skulls-${project.version}</jarName>
         <main.class>${project.groupId}.${project.artifactId}.${project.name}</main.class>
         <java.version>25</java.version>
-        <lombok.version>1.18.38</lombok.version>
+        <lombok.version>1.18.40</lombok.version>
         <flight.version>3.46.0</flight.version>
         <flight.path>ca.tweetzy</flight.path>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/ca/tweetzy/skulls/impl/economy/LegacyVaultEconomy.java
+++ b/src/main/java/ca/tweetzy/skulls/impl/economy/LegacyVaultEconomy.java
@@ -1,0 +1,93 @@
+/*
+ * Skulls
+ * Copyright 2022 Kiran Hart
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ca.tweetzy.skulls.impl.economy;
+
+import ca.tweetzy.flight.utils.Common;
+import ca.tweetzy.skulls.Skulls;
+import lombok.NonNull;
+import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+final class LegacyVaultEconomy extends MultiCurrencyEconomy {
+
+	private final Economy economy;
+
+	LegacyVaultEconomy() {
+		final RegisteredServiceProvider<Economy> rsp = Skulls.getInstance().getServer().getServicesManager().getRegistration(Economy.class);
+		if (rsp == null)
+			throw new IllegalStateException("Skulls could not find an economy provider for Vault.");
+
+		this.economy = rsp.getProvider();
+
+		if (!this.economy.isEnabled())
+			throw new IllegalStateException("Skulls found a Vault economy provider, but it is not enabled.");
+
+		Common.log("&aSetting up vault economy provider");
+	}
+
+	@Override
+	public String getName() {
+		return "Vault";
+	}
+
+	@Override
+	public boolean requiresExternalPlugin() {
+		return true;
+	}
+
+	@Override
+	public boolean has(@NonNull Player player, double amount) {
+		try {
+			return this.economy.has(player, amount);
+		} catch (RuntimeException ex) {
+			Common.log("&cFailed to check " + player.getName() + "'s balance using Vault economy: " + ex.getMessage());
+			return false;
+		}
+	}
+
+	@Override
+	public void withdraw(@NonNull Player player, double amount) {
+		final EconomyResponse response;
+		try {
+			response = this.economy.withdrawPlayer(player, amount);
+		} catch (RuntimeException ex) {
+			Common.log("&cFailed to withdraw from " + player.getName() + " using Vault economy: " + ex.getMessage());
+			return;
+		}
+
+		if (!response.transactionSuccess())
+			Common.log("&cFailed to withdraw from " + player.getName() + " using Vault economy: " + response.errorMessage);
+	}
+
+	@Override
+	public void deposit(@NonNull Player player, double amount) {
+		final EconomyResponse response;
+		try {
+			response = this.economy.depositPlayer(player, amount);
+		} catch (RuntimeException ex) {
+			Common.log("&cFailed to deposit to " + player.getName() + " using Vault economy: " + ex.getMessage());
+			return;
+		}
+
+		if (!response.transactionSuccess())
+			Common.log("&cFailed to deposit to " + player.getName() + " using Vault economy: " + response.errorMessage);
+	}
+}

--- a/src/main/java/ca/tweetzy/skulls/impl/economy/VaultEconomy.java
+++ b/src/main/java/ca/tweetzy/skulls/impl/economy/VaultEconomy.java
@@ -18,20 +18,8 @@
 
 package ca.tweetzy.skulls.impl.economy;
 
-import ca.tweetzy.flight.utils.Common;
-import ca.tweetzy.skulls.Skulls;
-import ca.tweetzy.skulls.exception.CurrencyNotFoundException;
 import lombok.NonNull;
-import net.milkbowl.vault.economy.Economy;
-import net.milkbowl.vault.economy.EconomyResponse;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.RegisteredServiceProvider;
-
-import java.lang.reflect.Method;
-import java.math.BigDecimal;
-import java.util.UUID;
 
 /**
  * Date Created: April 21 2022
@@ -41,163 +29,39 @@ import java.util.UUID;
  */
 public final class VaultEconomy extends MultiCurrencyEconomy {
 
-	private final String pluginName;
-	private BalanceCheck hasBalance;
-	private TransactionAction withdrawFunds;
-	private TransactionAction depositFunds;
+	private final MultiCurrencyEconomy economy;
 
 	public VaultEconomy() {
 		this(null);
 	}
 
 	public VaultEconomy(final String currencyName) {
-		this.pluginName = Skulls.getInstance().getName();
-		this.currencyName = currencyName == null || currencyName.trim().isEmpty() ? null : currencyName.trim();
-		setupEconomy();
-	}
-
-	private void setupEconomy() {
-		if (this.currencyName != null) {
-			setupVaultUnlockedEconomy();
-			return;
-		}
-
-		setupLegacyEconomy();
-	}
-
-	private void setupLegacyEconomy() {
-		final RegisteredServiceProvider<Economy> rsp = Skulls.getInstance().getServer().getServicesManager().getRegistration(Economy.class);
-		if (rsp == null)
-			throw new IllegalStateException("Skulls could not find an economy provider for Vault.");
-
-		final Economy economy = rsp.getProvider();
-
-		if (!economy.isEnabled())
-			throw new IllegalStateException("Skulls found a Vault economy provider, but it is not enabled.");
-
-		this.hasBalance = (player, amount) -> economy.has(player, amount.doubleValue());
-		this.withdrawFunds = (player, amount) -> {
-			final EconomyResponse response = economy.withdrawPlayer(player, amount.doubleValue());
-			return new TransactionResult(response.transactionSuccess(), response.errorMessage);
-		};
-		this.depositFunds = (player, amount) -> {
-			final EconomyResponse response = economy.depositPlayer(player, amount.doubleValue());
-			return new TransactionResult(response.transactionSuccess(), response.errorMessage);
-		};
-		Common.log("&aSetting up vault economy provider");
-	}
-
-	private void setupVaultUnlockedEconomy() {
-		final Plugin vaultPlugin = Bukkit.getServer().getPluginManager().getPlugin("Vault");
-		if (vaultPlugin == null)
-			throw new IllegalStateException("VaultUnlocked multi-currency requires VaultUnlocked to be installed.");
-
-		try {
-			final Class<?> economyClass = Class.forName("net.milkbowl.vault2.economy.Economy", false, vaultPlugin.getClass().getClassLoader());
-			final RegisteredServiceProvider<?> rsp = Skulls.getInstance().getServer().getServicesManager().getRegistration(economyClass);
-
-			if (rsp == null)
-				throw new IllegalStateException("Skulls could not find a VaultUnlocked economy provider.");
-
-			final Object economy = rsp.getProvider();
-			final Method isEnabled = economyClass.getMethod("isEnabled");
-			final Method hasMultiCurrencySupport = economyClass.getMethod("hasMultiCurrencySupport");
-			final Method hasCurrency = economyClass.getMethod("hasCurrency", String.class);
-			final Method has = economyClass.getMethod("has", String.class, UUID.class, String.class, BigDecimal.class);
-			final Method withdraw = economyClass.getMethod("withdraw", String.class, UUID.class, String.class, BigDecimal.class);
-			final Method deposit = economyClass.getMethod("deposit", String.class, UUID.class, String.class, BigDecimal.class);
-
-			if (!((Boolean) isEnabled.invoke(economy)))
-				throw new IllegalStateException("Skulls found a VaultUnlocked economy provider, but it is not enabled.");
-
-			if (!((Boolean) hasMultiCurrencySupport.invoke(economy)))
-				throw new IllegalStateException("Vault economy provider does not support multi-currency, but config requested currency: " + this.currencyName);
-
-			if (!((Boolean) hasCurrency.invoke(economy, this.currencyName)))
-				throw new CurrencyNotFoundException("Could not find the currency: '" + this.currencyName + "' from " + this.getName() + ", please check spelling or if it even exists.");
-
-			this.hasBalance = (player, amount) -> (Boolean) has.invoke(economy, this.pluginName, player.getUniqueId(), this.currencyName, amount);
-			this.withdrawFunds = (player, amount) -> toTransactionResult(withdraw.invoke(economy, this.pluginName, player.getUniqueId(), this.currencyName, amount));
-			this.depositFunds = (player, amount) -> toTransactionResult(deposit.invoke(economy, this.pluginName, player.getUniqueId(), this.currencyName, amount));
-			Common.log("&aSetting up vault economy provider with currency: " + this.currencyName);
-		} catch (ClassNotFoundException ex) {
-			throw new IllegalStateException("VaultUnlocked multi-currency requires VaultUnlocked. Install VaultUnlocked or change economy away from vault:" + this.currencyName, ex);
-		} catch (ReflectiveOperationException ex) {
-			throw new IllegalStateException("Could not hook into VaultUnlocked economy.", ex);
-		}
-	}
-
-	private TransactionResult toTransactionResult(final Object response) throws ReflectiveOperationException {
-		final Method transactionSuccess = response.getClass().getMethod("transactionSuccess");
-		final boolean success = (Boolean) transactionSuccess.invoke(response);
-		final Object errorMessage = response.getClass().getField("errorMessage").get(response);
-
-		return new TransactionResult(success, errorMessage == null ? null : errorMessage.toString());
+		this.economy = currencyName == null || currencyName.trim().isEmpty() ? new LegacyVaultEconomy() : new VaultUnlockedEconomy(currencyName);
+		this.currencyName = this.economy.getCurrencyName();
 	}
 
 	@Override
 	public String getName() {
-		return "Vault";
+		return this.economy.getName();
 	}
 
 	@Override
 	public boolean requiresExternalPlugin() {
-		return true;
+		return this.economy.requiresExternalPlugin();
 	}
 
 	@Override
 	public boolean has(@NonNull Player player, double amount) {
-		final BigDecimal value = BigDecimal.valueOf(amount);
-		try {
-			return this.hasBalance.apply(player, value);
-		} catch (ReflectiveOperationException ex) {
-			Common.log("&cFailed to check " + player.getName() + "'s balance using Vault economy: " + ex.getMessage());
-			return false;
-		}
+		return this.economy.has(player, amount);
 	}
 
 	@Override
 	public void withdraw(@NonNull Player player, double amount) {
-		final BigDecimal value = BigDecimal.valueOf(amount);
-		final TransactionResult response;
-		try {
-			response = this.withdrawFunds.apply(player, value);
-		} catch (ReflectiveOperationException ex) {
-			Common.log("&cFailed to withdraw from " + player.getName() + " using Vault economy: " + ex.getMessage());
-			return;
-		}
-
-		if (!response.success())
-			Common.log("&cFailed to withdraw from " + player.getName() + " using Vault economy: " + response.errorMessage());
+		this.economy.withdraw(player, amount);
 	}
 
 	@Override
 	public void deposit(@NonNull Player player, double amount) {
-		final BigDecimal value = BigDecimal.valueOf(amount);
-		final TransactionResult response;
-		try {
-			response = this.depositFunds.apply(player, value);
-		} catch (ReflectiveOperationException ex) {
-			Common.log("&cFailed to deposit to " + player.getName() + " using Vault economy: " + ex.getMessage());
-			return;
-		}
-
-		if (!response.success())
-			Common.log("&cFailed to deposit to " + player.getName() + " using Vault economy: " + response.errorMessage());
-	}
-
-	@FunctionalInterface
-	private interface BalanceCheck {
-
-		boolean apply(Player player, BigDecimal amount) throws ReflectiveOperationException;
-	}
-
-	@FunctionalInterface
-	private interface TransactionAction {
-
-		TransactionResult apply(Player player, BigDecimal amount) throws ReflectiveOperationException;
-	}
-
-	private record TransactionResult(boolean success, String errorMessage) {
+		this.economy.deposit(player, amount);
 	}
 }

--- a/src/main/java/ca/tweetzy/skulls/impl/economy/VaultUnlockedEconomy.java
+++ b/src/main/java/ca/tweetzy/skulls/impl/economy/VaultUnlockedEconomy.java
@@ -1,0 +1,106 @@
+/*
+ * Skulls
+ * Copyright 2022 Kiran Hart
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ca.tweetzy.skulls.impl.economy;
+
+import ca.tweetzy.flight.utils.Common;
+import ca.tweetzy.skulls.Skulls;
+import ca.tweetzy.skulls.exception.CurrencyNotFoundException;
+import lombok.NonNull;
+import net.milkbowl.vault2.economy.Economy;
+import net.milkbowl.vault2.economy.EconomyResponse;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+import java.math.BigDecimal;
+
+final class VaultUnlockedEconomy extends MultiCurrencyEconomy {
+
+	private final String pluginName;
+	private final Economy economy;
+
+	VaultUnlockedEconomy(@NonNull final String currencyName) {
+		this.pluginName = Skulls.getInstance().getName();
+		this.currencyName = currencyName.trim();
+
+		final RegisteredServiceProvider<Economy> rsp = Skulls.getInstance().getServer().getServicesManager().getRegistration(Economy.class);
+		if (rsp == null)
+			throw new IllegalStateException("Skulls could not find a VaultUnlocked economy provider.");
+
+		this.economy = rsp.getProvider();
+
+		if (!this.economy.isEnabled())
+			throw new IllegalStateException("Skulls found a VaultUnlocked economy provider, but it is not enabled.");
+
+		if (!this.economy.hasMultiCurrencySupport())
+			throw new IllegalStateException("Vault economy provider does not support multi-currency, but config requested currency: " + this.currencyName);
+
+		if (!this.economy.hasCurrency(this.currencyName))
+			throw new CurrencyNotFoundException("Could not find the currency: '" + this.currencyName + "' from " + this.getName() + ", please check spelling or if it even exists.");
+
+		Common.log("&aSetting up vault economy provider with currency: " + this.currencyName);
+	}
+
+	@Override
+	public String getName() {
+		return "Vault";
+	}
+
+	@Override
+	public boolean requiresExternalPlugin() {
+		return true;
+	}
+
+	@Override
+	public boolean has(@NonNull Player player, double amount) {
+		try {
+			return this.economy.has(this.pluginName, player.getUniqueId(), player.getWorld().getName(), this.currencyName, BigDecimal.valueOf(amount));
+		} catch (RuntimeException ex) {
+			Common.log("&cFailed to check " + player.getName() + "'s balance using Vault economy: " + ex.getMessage());
+			return false;
+		}
+	}
+
+	@Override
+	public void withdraw(@NonNull Player player, double amount) {
+		final EconomyResponse response;
+		try {
+			response = this.economy.withdraw(this.pluginName, player.getUniqueId(), player.getWorld().getName(), this.currencyName, BigDecimal.valueOf(amount));
+		} catch (RuntimeException ex) {
+			Common.log("&cFailed to withdraw from " + player.getName() + " using Vault economy: " + ex.getMessage());
+			return;
+		}
+
+		if (!response.transactionSuccess())
+			Common.log("&cFailed to withdraw from " + player.getName() + " using Vault economy: " + response.errorMessage);
+	}
+
+	@Override
+	public void deposit(@NonNull Player player, double amount) {
+		final EconomyResponse response;
+		try {
+			response = this.economy.deposit(this.pluginName, player.getUniqueId(), player.getWorld().getName(), this.currencyName, BigDecimal.valueOf(amount));
+		} catch (RuntimeException ex) {
+			Common.log("&cFailed to deposit to " + player.getName() + " using Vault economy: " + ex.getMessage());
+			return;
+		}
+
+		if (!response.transactionSuccess())
+			Common.log("&cFailed to deposit to " + player.getName() + " using Vault economy: " + response.errorMessage);
+	}
+}


### PR DESCRIPTION
Hey, I just wanted to apologize for the earlier Vault support PR.

After looking into it more carefully, I realized my original implementation made some wrong assumptions around legacy Vault vs VaultUnlocked multi-currency support. Sorry for the extra review and follow-up work that caused after you had already merged it.

I refactored the support so legacy Vault and VaultUnlocked are handled separately now, and I’ve tested the updated implementation on my end without any issues. This should make the behavior clearer and safer. Thanks again for taking the time to review and merge the PR.